### PR TITLE
Updated entrypoint.sh to use existing sql files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,15 @@ if [ "$1" = 'mysqld' ]; then
 		
 		echo 'FLUSH PRIVILEGES ;' >> "$tempSqlFile"
 		
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$file" in
+				*.sql)    echo "$0: copy $file into init-file"; cat $file >> $tempSqlFile ;;
+				*.sql.gz) echo "$0: copy $file into init-file"; gunzip -c $file >> $tempSqlFile ;;
+				*)        echo "$0: ignoring $file" ;;
+			esac
+			echo
+		done
+		
 		set -- "$@" --init-file="$tempSqlFile"
 	fi
 	


### PR DESCRIPTION
Updated the entrypoint.sh in order to append sql Files from /docker-entrypoint-initdb.d/* to append to the $tempSqlFile. With this change you can add sql files just like in the mysql base image.